### PR TITLE
fix: resolve packaged zstack directory in debug script

### DIFF
--- a/build/debug.sh
+++ b/build/debug.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
-base_dir=`dirname $0`/../
-build_dir=$base_dir/build
-zstack_dir=`find $build_dir -name zstack`
-jar_dir=$zstack_dir/lib
-conf_dir=$zstack_dir/conf
+base_dir=`dirname "$0"`/../
+build_dir="$base_dir/build"
+zstack_dir=`find "$build_dir" -type d -name zstack -print -quit`
+jar_dir="$zstack_dir/lib"
+conf_dir="$zstack_dir/conf"
 classpath=
 is_suspend="$1"
 
-if [ x"$is_suspend" == x"true" ]; then
+if [ x"$is_suspend" = x"true" ]; then
     java_optitons="-Xdebug -Xms256m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y"
 else
     java_optitons="-Xdebug -Xms256m -Xmx512m -XX:+HeapDumpOnOutOfMemoryError -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"
@@ -16,14 +16,14 @@ fi
 
 
 error_exit() {
-    echo $@ && exit1
+    echo "$@" && exit 1
 }
 
 build_classpath() {
-    jar_list=`ls $jar_dir`
+    jar_list=`ls "$jar_dir"`
     for jar in $jar_list
     do
-        jar_path=$jar_dir/$jar
+        jar_path="$jar_dir/$jar"
         classpath=$classpath:$jar_path
     done
     classpath=$classpath:$conf_dir
@@ -35,7 +35,7 @@ debug() {
 }
 
 main() {
-    [ x"$zstack_dir" == x"" ] && error_exit "Cannot find zstack dir under $build_dir, please run 'mvn package' before 'mvn exec:exec -Ddebug'"
+    [ x"$zstack_dir" = x"" ] && error_exit "Cannot find zstack dir under $build_dir, please run 'mvn package' before 'mvn exec:exec -Ddebug'"
     build_classpath
     debug
 }


### PR DESCRIPTION
## Summary

- Only select packaged `zstack` directories when locating the debug runtime.
- Exit with the existing friendly `mvn package` message when no distribution exists.
- Make the script's relevant path handling and test expressions POSIX-shell compatible.

Closes #12.

## Test plan

- `sh -n build/debug.sh`
- Run `build/debug.sh` without a packaged distribution and verify it exits with status 1 and prints the existing `mvn package` guidance.
