### PR TITLE
sdk: remove webhook wait entries after async callback completion

### DIFF
--- a/sdk/src/main/java/org/zstack/sdk/ZSClient.java
+++ b/sdk/src/main/java/org/zstack/sdk/ZSClient.java
@@ -241,6 +241,7 @@ public class ZSClient {
                     res.error.details = t.getMessage();
                     completion.complete(res);
                 }
+                waittingApis.remove(jobUuid);
             }
         }
 


### PR DESCRIPTION
Webhook-based async APIs are placed in the static waittingApis map before the request is sent. The sync path removes the entry after waiting, but the async callback path called completion.complete(res) without removing the finished job, causing long-running clients to retain stale Api references indefinitely.

Remove jobUuid from waittingApis once the async completion handler has been invoked. Sync webhook cleanup behavior is unchanged.

Fixes #11